### PR TITLE
テストのサンプルをscalatestのAnyFlatSpecで追加(#1)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,13 +23,18 @@ libraryDependencies ++= Seq(
 
 libraryDependencies += "com.github.jwt-scala" %% "jwt-circe" % "9.2.0"
 
+val scalatest = "org.scalatest" %% "scalatest" % "3.2.16" % "test"
+
 lazy val root = (project in file("."))
   .enablePlugins(JavaAppPackaging, RevolverPlugin)
   .settings(
     fork / run := true
   )
   .settings(
-    name := "sample"
+    name := "sample",
+    libraryDependencies ++= Seq(
+      scalatest,
+    ),
   )
 
 Revolver.enableDebugging(port = 5005, suspend = false)

--- a/src/test/scala/com/poksha/sample/application/auth/AuthServiceSpec.scala
+++ b/src/test/scala/com/poksha/sample/application/auth/AuthServiceSpec.scala
@@ -1,0 +1,36 @@
+package com.poksha.sample.application.auth
+
+import com.poksha.sample.domain.auth.{AuthUser, AuthUserId, AuthUserRepository}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+class AuthServiceSpec extends AnyFlatSpec with should.Matchers with AuthServiceSpecBase {
+  "AuthServiceSpec" should "not create user if the email already exists" in {
+    val sut = new AuthService
+    val actual = sut.create(
+      CreateAuthUserCommand.CreatePasswordUser(registeredEmail, registeredPass)
+    )
+    actual.isLeft shouldBe true
+  }
+}
+
+/**
+ * AuthServiceSpec に必要な要素を定義するためのベース trait
+ */
+sealed trait AuthServiceSpecBase {
+  val registeredEmail = "userEmail"
+  val registeredPass = "userPass"
+
+  val unregisteredEmail = "unregisteredEmail"
+
+  // FIXME モックを作るライブラリを使うことで分かりやすくなるなら、ライブラリの導入を検討する
+  implicit val mockAuthUserRepository: AuthUserRepository = new AuthUserRepository {
+    override def find(id: AuthUserId): Option[AuthUser] = ???
+    override def findByEmail(email: String): Option[AuthUser] = email match {
+      case _ if email == registeredEmail   => Some(AuthUser.EmailPasswordAuthUser(AuthUserId.generate(), "dummy", "dummy"))
+      case _ if email == unregisteredEmail => None
+      case _                               => sys.error(s"mockAuthUserRepository.findByEmail cannot handle the email [$email]. please set valid email as argument.")
+    }
+    override def save(user: AuthUser): Either[String, AuthUser] = ???
+  }
+}

--- a/src/test/scala/com/poksha/sample/domain/auth/AuthUserPasswordSpec.scala
+++ b/src/test/scala/com/poksha/sample/domain/auth/AuthUserPasswordSpec.scala
@@ -1,0 +1,11 @@
+package com.poksha.sample.domain.auth
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class AuthUserPasswordSpec extends AnyFlatSpec {
+  "AuthUserPassword" should "has hashed password as value" in {
+      val plainPassword = "password"
+      val actual = AuthUserPassword(AuthUserPassword(plainPassword).hash())
+      assert(actual.value != plainPassword)
+    }
+}


### PR DESCRIPTION
### 概要

テストのサンプルを追加してみました

### 対応したこと (What)

- テストサンプル追加
- scalatest を使いました
  - https://www.scalatest.org

### 対応した理由 (Why)

- テストサンプル追加の理由
  - issue #1 に上がってたので
  - テストを書きたい時に参考にするベースを追加したかったので
- scalatest を使いましたの理由
  - Scalaの資料や記事などが多く、情報が多い
  - 公式のドキュメントが充実している
  - スター数が多い

# 動作確認方法

- sbt test を実行し、テストが2つパスすること

# その他

- 全ての処理をガチガチにテスト書かなかった理由
  - ~めんどくさかったので~
  - ドメイン知識や担保したいロジックがわからず、現時点で担保したい箇所が明瞭になってから作成した方が良いと考えたため
