### PR TITLE
#19 dependencies を別のクラスで定義するようにした

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,28 +1,10 @@
+import Dependencies._
+
 ThisBuild / version := "0.1.0-SNAPSHOT"
 
 ThisBuild / scalaVersion := "2.12.17"
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
-
-// https://mvnrepository.com/artifact/at.favre.lib/bcrypt
-libraryDependencies += "at.favre.lib" % "bcrypt" % "0.10.2"
-
-// https://mvnrepository.com/artifact/org.slf4j/slf4j-api
-libraryDependencies += "org.slf4j" % "slf4j-api" % "2.0.7"
-
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.7"
-
-val http4sVersion = "0.23.18"
-
-libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-ember-client" % http4sVersion,
-  "org.http4s" %% "http4s-ember-server" % http4sVersion,
-  "org.http4s" %% "http4s-dsl" % http4sVersion
-)
-
-libraryDependencies += "com.github.jwt-scala" %% "jwt-circe" % "9.2.0"
-
-val scalatest = "org.scalatest" %% "scalatest" % "3.2.16" % "test"
 
 lazy val root = (project in file("."))
   .enablePlugins(JavaAppPackaging, RevolverPlugin)
@@ -32,8 +14,15 @@ lazy val root = (project in file("."))
   .settings(
     name := "sample",
     libraryDependencies ++= Seq(
-      scalatest
-    )
+      BCrypt.lib,
+      Slf4j.lib,
+      Logback.lib,
+      JwtScala.lib,
+      TypesafeConfig.lib,
+      ScalaTest.lib
+    ) ++ Circe.libs
+      ++ Doobie.libs
+      ++ Http4s.libs
   )
 
 Revolver.enableDebugging(port = 5005, suspend = false)
@@ -41,24 +30,6 @@ reStartArgs := Seq("--watch", "src/main/scala")
 
 scalacOptions ++= Seq("-Ypartial-unification")
 
-libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-circe" % http4sVersion,
-  // Optional for auto-derivation of JSON codecs
-  "io.circe" %% "circe-generic" % "0.14.5",
-  // Optional for string interpolation to JSON model
-  "io.circe" %% "circe-literal" % "0.14.5"
-)
-
 addCompilerPlugin(
   "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
 )
-
-lazy val doobieVersion = "1.0.0-RC1"
-
-libraryDependencies ++= Seq(
-  "org.tpolecat" %% "doobie-core" % doobieVersion,
-  "org.tpolecat" %% "doobie-postgres" % doobieVersion,
-  "org.tpolecat" %% "doobie-specs2" % doobieVersion
-)
-
-libraryDependencies += "com.typesafe" % "config" % "1.4.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,59 @@
+import sbt._
+
+object Dependencies {
+
+  // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
+  object Slf4j {
+    lazy val lib = "org.slf4j" % "slf4j-api" % "2.0.7"
+  }
+
+  object Logback {
+    lazy val lib = "ch.qos.logback" % "logback-classic" % "1.4.7"
+  }
+
+  // https://mvnrepository.com/artifact/at.favre.lib/bcrypt
+  object BCrypt {
+    lazy val lib = "at.favre.lib" % "bcrypt" % "0.10.2"
+  }
+
+  object JwtScala {
+    lazy val lib = "com.github.jwt-scala" %% "jwt-circe" % "9.2.0"
+  }
+
+  object Doobie {
+    lazy val version = "1.0.0-RC1"
+    lazy val libs = Seq(
+      "org.tpolecat" %% "doobie-core" % version,
+      "org.tpolecat" %% "doobie-postgres" % version,
+      "org.tpolecat" %% "doobie-specs2" % version
+    )
+  }
+
+  object Http4s {
+    lazy val version = "0.23.18"
+    lazy val libs = Seq(
+      "org.http4s" %% "http4s-ember-client" % version,
+      "org.http4s" %% "http4s-ember-server" % version,
+      "org.http4s" %% "http4s-dsl" % version,
+      "org.http4s" %% "http4s-circe" % version
+    )
+  }
+
+  object Circe {
+    lazy val version = "0.14.5"
+    lazy val libs = Seq(
+      // Optional for auto-derivation of JSON codecs
+      "io.circe" %% "circe-generic" % Circe.version,
+      // Optional for string interpolation to JSON model
+      "io.circe" %% "circe-literal" % Circe.version
+    )
+  }
+
+  object TypesafeConfig {
+    lazy val lib = "com.typesafe" % "config" % "1.4.2"
+  }
+
+  object ScalaTest {
+    lazy val lib = "org.scalatest" %% "scalatest" % "3.2.16" % "test"
+  }
+}


### PR DESCRIPTION
#19 の対応です
libraryDependenciesとして取り込むライブラリ群を`Dependencies.scala`で定義するようにして、`build.sbt`の見通しをよくしました