### PR TITLE
Update setup

### DIFF
--- a/.github/workflows/run_sbt_test_on_push.yaml
+++ b/.github/workflows/run_sbt_test_on_push.yaml
@@ -71,4 +71,4 @@ jobs:
       - name: Run sbt test 
         id: run-sbt-test
         run: |
-          sbt test
+          sudo sbt test

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,14 @@ dev/ps:
 
 dev/logs/web:
 	docker compose -f docker-compose.dev.yml logs -f web
+
+dev/db/migrate:
+	docker compose -f docker-compose.dev.yml run --rm db_migrate
+
+dev/setup: dev/build dev/up dev/db/migrate
+
+setup:
+	docker compose --profile app -f docker-compose.dev.yml build
+	docker compose --profile app -f docker-compose.dev.yml up -d
+	docker compose -f docker-compose.dev.yml run --rm db_migrate
+

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,3 @@ dev/db/migrate:
 	docker compose -f docker-compose.dev.yml run --rm db_migrate
 
 dev/setup: dev/build dev/up dev/db/migrate
-
-setup:
-	docker compose --profile app -f docker-compose.dev.yml build
-	docker compose --profile app -f docker-compose.dev.yml up -d
-	docker compose -f docker-compose.dev.yml run --rm db_migrate
-

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Scalaとhttp4sを使ったWEB APIのテンプレートです。
 make dev/setup
 ```
 
-statusがhealthyになったら、http://localhost:8000/ にアクセス
+statusがhealthyになったら、http://localhost:8080/ にアクセス
 
 ```bash
 make dev/ps

--- a/README.md
+++ b/README.md
@@ -4,39 +4,8 @@ Scalaとhttp4sを使ったWEB APIのテンプレートです。
 
 ## 環境構築
 
-- 開発したい人 → webサーバはローカルで構築、その他はdockerで構築
-- 動作させたい人 → dockerで構築
-
-### ローカルで構築
-
-#### 依存サービスの構築
-
 ```bash
 make dev/setup
 ```
 
-#### webサーバの構築
-
-sbtのインストール
-
-https://www.scala-sbt.org/1.x/docs/ja/Setup.html
-
-テスト実行
-
-```bash
-sbt test
-```
-
-起動
-
-```bash
-sbt ~reStart
-```
-
 http://localhost:8000/ にアクセス
-
-### dockerで構築
-
-```bash
-make setup
-```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# WEB API テンプレート
+
+Scalaとhttp4sを使ったWEB APIのテンプレートです。
+
+## 環境構築
+
+- 開発したい人 → webサーバはローカルで構築、その他はdockerで構築
+- 動作させたい人 → dockerで構築
+
+### ローカルで構築
+
+#### 依存サービスの構築
+
+```bash
+make dev/setup
+```
+
+#### webサーバの構築
+
+sbtのインストール
+
+https://www.scala-sbt.org/1.x/docs/ja/Setup.html
+
+テスト実行
+
+```bash
+sbt test
+```
+
+起動
+
+```bash
+sbt ~reStart
+```
+
+http://localhost:8000/ にアクセス
+
+### dockerで構築
+
+```bash
+make setup
+```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,20 @@ Scalaとhttp4sを使ったWEB APIのテンプレートです。
 
 ## 環境構築
 
+以下を実行してください。(結構時間かかります。)
+
 ```bash
 make dev/setup
 ```
 
-http://localhost:8000/ にアクセス
+statusがhealthyになったら、http://localhost:8000/ にアクセス
+
+```bash
+make dev/ps
+```
+
+```text
+NAME                     COMMAND                  SERVICE             STATUS              PORTS
+web-api-template-db-1    "docker-entrypoint.s…"   db                  running (healthy)   0.0.0.0:5432->5432/tcp
+web-api-template-web-1   "sbt ~reStart"           web                 running (healthy)   0.0.0.0:8080->8080/tcp
+```

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,6 +13,8 @@ services:
       - DB_USER=postgres
       - DB_PASSWORD=password
       - PORT=8080
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
     depends_on:
       - db
   db:
@@ -23,6 +25,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
       - POSTGRES_DB=authentication
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
     volumes:
       - db_data:/var/lib/postgresql/data
   db_migrate:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,9 +12,9 @@ services:
       - DB_URL=jdbc:postgresql:authentication
       - DB_USER=postgres
       - DB_PASSWORD=password
+      - PORT=8080
     depends_on:
       - db
-    profiles: ["app"]
   db:
     image: postgres:15-alpine
     ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,7 +23,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
       - POSTGRES_DB=authentication
-    profiles: ["database"]
+    volumes:
+      - db_data:/var/lib/postgresql/data
   db_migrate:
     build:
       context: ./docker/migrate
@@ -32,4 +33,8 @@ services:
       - db
     # docker composeで起動時は開発用途なので migrate up で良い、運用時は command の arguments を調整することで down や up 1 などで何を適用するか決定する
     command: ["-database", "postgres://postgres:password@db:5432/authentication?sslmode=disable", "-path", "/migrations/", "up"]
-    profiles: ["database"]
+    profiles: ["migration"]
+
+volumes:
+  db_data:
+

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,5 +1,5 @@
 # ベースイメージ
-FROM openjdk:19-jdk-alpine3.16
+FROM amazoncorretto:20-alpine3.18
 
 ARG SBT_VERSION=1.8.2
 
@@ -22,4 +22,4 @@ RUN sbt -V
 EXPOSE 8080
 
 # アプリケーションを実行
-CMD ["sbt", "~reStart"]
+CMD ["sbt", "run"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -22,4 +22,4 @@ RUN sbt -V
 EXPOSE 8080
 
 # アプリケーションを実行
-CMD ["sbt", "run"]
+CMD ["sbt", "~reStart"]

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -8,7 +8,7 @@ application {
     level = ${?LOG_LEVEL}
   }
   server {
-    port = 8000
+    port = 8080
     port = ${?PORT}
     host = "0.0.0.0"
   }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,4 +1,5 @@
 application {
+  name = "poksha-sample-api"
   logging {
     // FIXME 環境変数がない場合のデフォルト値をいい感じに設定したい
     dir = "./logs"
@@ -6,10 +7,18 @@ application {
     level = "INFO"
     level = ${?LOG_LEVEL}
   }
+  server {
+    port = 8000
+    port = ${?PORT}
+    host = "0.0.0.0"
+  }
 }
 
 database {
   postgres {
+    url = "jdbc:postgresql://localhost:5432/authentication"
+    user = "postgres"
+    pass = "password"
     url = ${?DB_URL}
     user = ${?DB_USER}
     pass = ${?DB_PASSWORD}

--- a/src/main/scala/com/poksha/sample/infrastructure/api/config/AppConfig.scala
+++ b/src/main/scala/com/poksha/sample/infrastructure/api/config/AppConfig.scala
@@ -1,0 +1,18 @@
+package com.poksha.sample.infrastructure.api.config
+
+case class AppConfig private (
+    port: Int,
+    host: String,
+)
+
+object AppConfig {
+  def apply(
+      port: Int = 8080,
+      host: String = "0.0.0.0"
+   ): AppConfig = {
+    new AppConfig(
+      port,
+      host,
+    )
+  }
+}


### PR DESCRIPTION
環境構築用のコマンドを整えたり、READMEを整理したりしました。

- READMEに構築方法を記述
- 環境構築用のコマンドを追加
- web serverのポートとhostを環境変数で与えられるようにしました
  - Cloud Runとか、コンテナサービスに載せる時、PORTで指定できるのを求められることがあるので
- docker composeにhealthcheckを追加
  - 初回起動までに結構時間かかるので、psで状態を把握できるようにして、環境構築で詰まりにくくするため
- JDKのイメージを変更
  - m1 macだと使えなかったので変更 